### PR TITLE
Feature/헤더 UI 개선

### DIFF
--- a/pages/chatbot/index.tsx
+++ b/pages/chatbot/index.tsx
@@ -1,0 +1,10 @@
+import OnePageLayout from "@layouts/OnePageLayout";
+import Chatbot from "@scenes/Chatbot";
+
+export default function ChatbotPage() {
+  return (
+    <OnePageLayout>
+      <Chatbot />
+    </OnePageLayout>
+  );
+}

--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -5,7 +5,7 @@ export default function Logo() {
   return (
     <Link href={"/"}>
       <ButtonWrapper>
-        <span className="pb-[6px] pl-[4px] text-3xl font-bold text-main_color dark:text-main_color">
+        <span className="pb-[6px] pl-[4px] text-3xl font-medium text-main_color dark:text-main_color">
           Senior+
         </span>
       </ButtonWrapper>

--- a/src/layouts/Header/DesktopHeader/NavLinks.tsx
+++ b/src/layouts/Header/DesktopHeader/NavLinks.tsx
@@ -4,15 +4,20 @@ import ButtonWrapper from "@components/Animation/ButtonWrapper";
 // isClicked를 기준으로 Menu 토글
 export default function NavLinks() {
   return (
-    <div className="flex gap-2 text-xl font-bold md:gap-4">
-      <Link href={"/educations"} className="col-end w-[100px] pt-[6px]">
+    <div className="flex gap-2 text-xl font-medium md:gap-4">
+      <Link href={"/educations"} className="col-end w-[84px] pt-[6px]">
         <ButtonWrapper>
           <span className="text-main_color">교육 정보</span>
         </ButtonWrapper>
       </Link>
-      <Link href={"/posts"} className="col-end w-[100px] pt-[6px]">
+      <Link href={"/posts"} className="col-end w-[98px] pt-[6px]">
         <ButtonWrapper>
           <span className="text-main_color">자유게시판</span>
+        </ButtonWrapper>
+      </Link>
+      <Link href={"/chatbot"} className="col-end w-[40px] pt-[6px]">
+        <ButtonWrapper>
+          <span className="text-main_color">챗봇</span>
         </ButtonWrapper>
       </Link>
     </div>

--- a/src/layouts/Header/DesktopHeader/NavLinks.tsx
+++ b/src/layouts/Header/DesktopHeader/NavLinks.tsx
@@ -8,7 +8,7 @@ export default function NavLinks() {
 
   return (
     <div className="flex gap-2 text-xl font-medium  md:gap-4">
-      <Link href={"/educations"} className="col-end w-[84px] pt-[6px]">
+      <Link href={"/educations"} className="col-end pt-[6px]">
         <ButtonWrapper>
           <span
             className={`text-lg ${
@@ -19,7 +19,7 @@ export default function NavLinks() {
           </span>
         </ButtonWrapper>
       </Link>
-      <Link href={"/posts"} className="col-end w-[98px] pt-[6px]">
+      <Link href={"/posts"} className="col-end pt-[6px]">
         <ButtonWrapper>
           <span
             className={`text-lg ${
@@ -30,7 +30,7 @@ export default function NavLinks() {
           </span>
         </ButtonWrapper>
       </Link>
-      <Link href={"/chatbot"} className="col-end w-[40px] pt-[6px]">
+      <Link href={"/chatbot"} className="col-end pt-[6px]">
         <ButtonWrapper>
           <span
             className={`text-lg ${

--- a/src/layouts/Header/DesktopHeader/NavLinks.tsx
+++ b/src/layouts/Header/DesktopHeader/NavLinks.tsx
@@ -1,23 +1,44 @@
+import { useRouter } from "next/router";
 import Link from "next/link";
 import ButtonWrapper from "@components/Animation/ButtonWrapper";
 
-// isClicked를 기준으로 Menu 토글
 export default function NavLinks() {
+  const router = useRouter();
+  const pathsArr = router.asPath.split("/");
+
   return (
-    <div className="flex gap-2 text-xl font-medium md:gap-4">
+    <div className="flex gap-2 text-xl font-medium  md:gap-4">
       <Link href={"/educations"} className="col-end w-[84px] pt-[6px]">
         <ButtonWrapper>
-          <span className="text-main_color">교육 정보</span>
+          <span
+            className={`text-lg ${
+              pathsArr.includes("educations") ? "font-bold text-main_color" : ""
+            }`}
+          >
+            교육 정보
+          </span>
         </ButtonWrapper>
       </Link>
       <Link href={"/posts"} className="col-end w-[98px] pt-[6px]">
         <ButtonWrapper>
-          <span className="text-main_color">자유게시판</span>
+          <span
+            className={`text-lg ${
+              pathsArr.includes("posts") ? "font-bold text-main_color" : ""
+            }`}
+          >
+            자유게시판
+          </span>
         </ButtonWrapper>
       </Link>
       <Link href={"/chatbot"} className="col-end w-[40px] pt-[6px]">
         <ButtonWrapper>
-          <span className="text-main_color">챗봇</span>
+          <span
+            className={`text-lg ${
+              pathsArr.includes("chatbot") ? "font-bold text-main_color" : ""
+            }`}
+          >
+            챗봇
+          </span>
         </ButtonWrapper>
       </Link>
     </div>

--- a/src/layouts/Header/DesktopHeader/index.tsx
+++ b/src/layouts/Header/DesktopHeader/index.tsx
@@ -1,0 +1,11 @@
+import Logo from "@components/Logo";
+import NavLinks from "./NavLinks";
+
+export default function DesktopHeader() {
+  return (
+    <div className="container mx-auto flex h-16 items-center justify-between px-4">
+      <Logo />
+      <NavLinks />
+    </div>
+  );
+}

--- a/src/layouts/Header/MobileHeader/index.tsx
+++ b/src/layouts/Header/MobileHeader/index.tsx
@@ -5,6 +5,8 @@ import Logo from "@components/Logo";
 import Menu from "./menu";
 import MenuToggle from "./menuToggle";
 
+import { ICurrentPage } from "@type/link";
+
 export default function MobileHeader({
   showMenu,
   setShowMenu,
@@ -13,8 +15,14 @@ export default function MobileHeader({
   setShowMenu: Dispatch<SetStateAction<boolean>>;
 }) {
   const router = useRouter();
+
   const pathsArr = router.asPath.split("/");
   const isDetailPage = router.query.id ? true : false;
+  const currentPage: ICurrentPage = {
+    educations: pathsArr.includes("educations"),
+    posts: pathsArr.includes("posts"),
+    chatbot: pathsArr.includes("chatbot"),
+  };
 
   return (
     <>
@@ -22,18 +30,26 @@ export default function MobileHeader({
       {isDetailPage ? (
         <div className="container relative mx-auto grid h-16 grid-cols-3 justify-between px-4">
           {/* 디테일 페이지 헤더 */}
-          <button className="flex items-center justify-start">
+          <button
+            className="flex items-center justify-start"
+            onClick={
+              () => router.back()
+              // router.push(`/${pathsArr[1]}`, undefined, { scroll: false })
+            }
+          >
             <i className="ri-arrow-left-s-line text-4xl text-main_color"></i>
             <span className="text-lg font-bold text-main_color">뒤로</span>
           </button>
 
           <div className="col-center">
             <h2 className="text-xl font-medium text-main_color">
-              {pathsArr.includes("educations")
+              {currentPage.educations
                 ? "교육 정보"
-                : pathsArr.includes("posts")
+                : currentPage.posts
                 ? "자유게시판"
-                : "챗봇"}
+                : currentPage.chatbot
+                ? "챗봇"
+                : ""}
             </h2>
           </div>
 
@@ -50,7 +66,7 @@ export default function MobileHeader({
       )}
 
       {/* 링크 영역 */}
-      {showMenu && <Menu />}
+      {showMenu && <Menu currentPage={currentPage} />}
     </>
   );
 }

--- a/src/layouts/Header/MobileHeader/index.tsx
+++ b/src/layouts/Header/MobileHeader/index.tsx
@@ -1,0 +1,26 @@
+import { Dispatch, SetStateAction } from "react";
+
+import Logo from "@components/Logo";
+import Menu from "./menu";
+import MenuToggle from "./menuToggle";
+
+export default function MobileHeader({
+  showMenu,
+  setShowMenu,
+}: {
+  showMenu: boolean;
+  setShowMenu: Dispatch<SetStateAction<boolean>>;
+}) {
+  return (
+    <>
+      {/* 헤더 영역 */}
+      <div className="container relative mx-auto flex h-16 items-center justify-between px-4">
+        <Logo />
+        <MenuToggle setShowMenu={setShowMenu} />
+      </div>
+
+      {/* 링크 영역 */}
+      {showMenu && <Menu />}
+    </>
+  );
+}

--- a/src/layouts/Header/MobileHeader/index.tsx
+++ b/src/layouts/Header/MobileHeader/index.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction } from "react";
+import { useRouter } from "next/router";
 
 import Logo from "@components/Logo";
 import Menu from "./menu";
@@ -11,13 +12,42 @@ export default function MobileHeader({
   showMenu: boolean;
   setShowMenu: Dispatch<SetStateAction<boolean>>;
 }) {
+  const router = useRouter();
+  const pathsArr = router.asPath.split("/");
+  const isDetailPage = router.query.id ? true : false;
+
   return (
     <>
       {/* 헤더 영역 */}
-      <div className="container relative mx-auto flex h-16 items-center justify-between px-4">
-        <Logo />
-        <MenuToggle setShowMenu={setShowMenu} />
-      </div>
+      {isDetailPage ? (
+        <div className="container relative mx-auto grid h-16 grid-cols-3 justify-between px-4">
+          {/* 디테일 페이지 헤더 */}
+          <button className="flex items-center justify-start">
+            <i className="ri-arrow-left-s-line text-4xl text-main_color"></i>
+            <span className="text-lg font-bold text-main_color">뒤로</span>
+          </button>
+
+          <div className="col-center">
+            <h2 className="text-xl font-medium text-main_color">
+              {pathsArr.includes("educations")
+                ? "교육 정보"
+                : pathsArr.includes("posts")
+                ? "자유게시판"
+                : "챗봇"}
+            </h2>
+          </div>
+
+          <div className="flex items-center justify-end">
+            <MenuToggle setShowMenu={setShowMenu} />
+          </div>
+        </div>
+      ) : (
+        <div className="container relative mx-auto flex h-16 items-center justify-between px-4">
+          {/* 일반 페이지 헤더 */}
+          <Logo />
+          <MenuToggle setShowMenu={setShowMenu} />
+        </div>
+      )}
 
       {/* 링크 영역 */}
       {showMenu && <Menu />}

--- a/src/layouts/Header/MobileHeader/index.tsx
+++ b/src/layouts/Header/MobileHeader/index.tsx
@@ -54,14 +54,14 @@ export default function MobileHeader({
           </div>
 
           <div className="flex items-center justify-end">
-            <MenuToggle setShowMenu={setShowMenu} />
+            <MenuToggle showMenu={showMenu} setShowMenu={setShowMenu} />
           </div>
         </div>
       ) : (
         <div className="container relative mx-auto flex h-16 items-center justify-between px-4">
           {/* 일반 페이지 헤더 */}
           <Logo />
-          <MenuToggle setShowMenu={setShowMenu} />
+          <MenuToggle showMenu={showMenu} setShowMenu={setShowMenu} />
         </div>
       )}
 

--- a/src/layouts/Header/MobileHeader/menu.tsx
+++ b/src/layouts/Header/MobileHeader/menu.tsx
@@ -1,0 +1,72 @@
+import { useRouter } from "next/router";
+import { motion } from "framer-motion";
+
+import ButtonWrapper from "@components/Animation/ButtonWrapper";
+import Link from "next/link";
+
+export default function Menu() {
+  const router = useRouter();
+  const pathsArr = router.asPath.split("/");
+
+  return (
+    <>
+      <motion.div
+        key={"menu"}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+        className="absolute left-0 top-16 w-screen bg-white shadow-sm"
+      >
+        <div className="col-center border-t border-main_color/30">
+          <Link
+            href={"/educations"}
+            className="col-center w-full border-b border-main_color/30 py-2"
+          >
+            <ButtonWrapper>
+              <span
+                className={`text-lg ${
+                  pathsArr.includes("educations")
+                    ? "font-bold text-main_color"
+                    : ""
+                }`}
+              >
+                교육 정보
+              </span>
+            </ButtonWrapper>
+          </Link>
+          <Link
+            href={"/posts"}
+            className="col-center w-full border-b border-main_color/30 py-2"
+          >
+            <ButtonWrapper>
+              <span
+                className={`text-lg ${
+                  pathsArr.includes("posts") ? "font-bold text-main_color" : ""
+                }`}
+              >
+                자유게시판
+              </span>
+            </ButtonWrapper>
+          </Link>
+          <Link
+            href={"/chatbot"}
+            className="col-center w-full border-b border-main_color/30 py-2"
+          >
+            <ButtonWrapper>
+              <span
+                className={`text-lg ${
+                  pathsArr.includes("chatbot")
+                    ? "font-bold text-main_color"
+                    : ""
+                }`}
+              >
+                챗봇
+              </span>
+            </ButtonWrapper>
+          </Link>
+        </div>
+      </motion.div>
+    </>
+  );
+}

--- a/src/layouts/Header/MobileHeader/menu.tsx
+++ b/src/layouts/Header/MobileHeader/menu.tsx
@@ -1,13 +1,10 @@
-import { useRouter } from "next/router";
+import Link from "next/link";
 import { motion } from "framer-motion";
 
 import ButtonWrapper from "@components/Animation/ButtonWrapper";
-import Link from "next/link";
+import { ICurrentPage } from "@type/link";
 
-export default function Menu() {
-  const router = useRouter();
-  const pathsArr = router.asPath.split("/");
-
+export default function Menu({ currentPage }: { currentPage: ICurrentPage }) {
   return (
     <>
       <motion.div
@@ -26,9 +23,7 @@ export default function Menu() {
             <ButtonWrapper>
               <span
                 className={`text-lg ${
-                  pathsArr.includes("educations")
-                    ? "font-bold text-main_color"
-                    : ""
+                  currentPage.educations ? "font-bold text-main_color" : ""
                 }`}
               >
                 교육 정보
@@ -42,7 +37,7 @@ export default function Menu() {
             <ButtonWrapper>
               <span
                 className={`text-lg ${
-                  pathsArr.includes("posts") ? "font-bold text-main_color" : ""
+                  currentPage.posts ? "font-bold text-main_color" : ""
                 }`}
               >
                 자유게시판
@@ -56,9 +51,7 @@ export default function Menu() {
             <ButtonWrapper>
               <span
                 className={`text-lg ${
-                  pathsArr.includes("chatbot")
-                    ? "font-bold text-main_color"
-                    : ""
+                  currentPage.chatbot ? "font-bold text-main_color" : ""
                 }`}
               >
                 챗봇

--- a/src/layouts/Header/MobileHeader/menu.tsx
+++ b/src/layouts/Header/MobileHeader/menu.tsx
@@ -16,7 +16,7 @@ export default function Menu() {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
-        className="absolute left-0 top-16 w-screen bg-white shadow-sm"
+        className="absolute left-0 top-16 w-screen bg-white font-medium shadow-sm"
       >
         <div className="col-center border-t border-main_color/30">
           <Link

--- a/src/layouts/Header/MobileHeader/menuToggle.tsx
+++ b/src/layouts/Header/MobileHeader/menuToggle.tsx
@@ -1,0 +1,16 @@
+import { Dispatch, SetStateAction } from "react";
+
+export default function MenuToggle({
+  setShowMenu,
+}: {
+  setShowMenu: Dispatch<SetStateAction<boolean>>;
+}) {
+  return (
+    <button
+      className="col-center h-8 w-8"
+      onClick={() => setShowMenu((prev) => !prev)}
+    >
+      <i className="ri-menu-3-line text-2xl font-bold text-main_color" />
+    </button>
+  );
+}

--- a/src/layouts/Header/MobileHeader/menuToggle.tsx
+++ b/src/layouts/Header/MobileHeader/menuToggle.tsx
@@ -1,16 +1,26 @@
 import { Dispatch, SetStateAction } from "react";
 
 export default function MenuToggle({
+  showMenu,
   setShowMenu,
 }: {
+  showMenu: boolean;
   setShowMenu: Dispatch<SetStateAction<boolean>>;
 }) {
   return (
-    <button
-      className="col-center h-8 w-8"
-      onClick={() => setShowMenu((prev) => !prev)}
-    >
-      <i className="ri-menu-3-line text-2xl font-bold text-main_color" />
-    </button>
+    <>
+      {showMenu ? (
+        <button onClick={() => setShowMenu(false)}>
+          <i className="ri-close-line text-3xl font-bold text-main_color" />
+        </button>
+      ) : (
+        <button
+          className="col-center h-8 w-8"
+          onClick={() => setShowMenu(true)}
+        >
+          <i className="ri-menu-3-line text-2xl font-bold text-main_color" />
+        </button>
+      )}
+    </>
   );
 }

--- a/src/layouts/Header/index.tsx
+++ b/src/layouts/Header/index.tsx
@@ -1,12 +1,15 @@
-import Logo from "./HeaderItem/Logo";
-import NavLinks from "./HeaderItem/NavLinks";
-
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
+
+import DesktopHeader from "./DesktopHeader";
+import MobileHeader from "./MobileHeader";
 
 export default function Header() {
   // 헤더가 나타나는지, 사라지는지 추적
   const [showHeader, setShowHeader] = useState(true);
+
+  // 모바일 헤더의 메뉴가 나타나는지, 사라지는지 추적
+  const [showMenu, setShowMenu] = useState(false);
 
   // 직전 스크롤의 위치 추적
   const [prevScrollPos, setPrevScrollPos] = useState(0);
@@ -27,9 +30,11 @@ export default function Header() {
         setPrevScrollPos(currentScrollPos);
       };
 
-      if (window !== undefined)
+      if (window !== undefined) {
         // 스크롤 할 때마다 handleScroll 실행
         window.addEventListener("scroll", handleScroll);
+        setShowMenu(false);
+      }
 
       // 이벤트 리스너 해제
       return () => {
@@ -59,9 +64,14 @@ export default function Header() {
         transition={{ duration: 0.3 }}
         className="fixed top-0 z-40 w-full bg-white shadow-sm"
       >
-        <div className="container mx-auto flex h-16 items-center justify-between px-4">
-          <Logo />
-          <NavLinks />
+        {/* 데스크탑용 헤더 */}
+        <div className="hidden w-full md:block">
+          <DesktopHeader />
+        </div>
+
+        {/* 모바일용 헤더 */}
+        <div className="block w-full md:hidden">
+          <MobileHeader showMenu={showMenu} setShowMenu={setShowMenu} />
         </div>
       </motion.header>
     </>

--- a/src/scenes/Chatbot/index.tsx
+++ b/src/scenes/Chatbot/index.tsx
@@ -1,0 +1,3 @@
+export default function Chatbot() {
+  return <div>chatbot</div>;
+}

--- a/src/type/link.ts
+++ b/src/type/link.ts
@@ -1,0 +1,5 @@
+export interface ICurrentPage {
+  educations: boolean;
+  posts: boolean;
+  chatbot: boolean;
+}


### PR DESCRIPTION
## 작업 요약

> 1~2줄 사이의 요약 설명

- 헤더 안의 컴포넌트를 DesktopHeader와 MobileHeader로 나누어 진행
- md 부터 DesktopHeader를 display:block 처리 
- md 부터 MobileHeader를 display:hidden 처리
- 메뉴 토글 버튼을 다시 생성
- chatbot 페이지 추가
- 현재 페이지를 고려한 NavLink의 css 추가 적용

## 이미지

![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/717969ea-60d2-4389-bf40-a4e14b0ad382)
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/1d1a5341-d056-4e51-b14b-f19226b1fa44)
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/1bbb3966-94a6-4c6b-83e8-32861d7fc5ca)
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/9fa8bc4d-29e8-4067-b0b9-d7e4de81a5cc)
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/41d2657a-d2c5-4235-bcb1-112e28083c14)
메뉴토글을 클릭했을 때 교육정보라는 글자가 두 번 나오는 것이 보기 좋지 않은 상황.
