### PR TITLE
Hotfix/user의 age 값 조정

### DIFF
--- a/public/data/rankingData.ts
+++ b/public/data/rankingData.ts
@@ -116,11 +116,11 @@ export const rankEducationUserData = {
 
 export const rankEducationUserKeywords = {
   data: [
-    { id: 1, keyword: "건강", hits: 50 },
-    { id: 2, keyword: "취업", hits: 30 },
-    { id: 3, keyword: "생애설계", hits: 30 },
-    { id: 4, keyword: "교육", hits: 20 },
-    { id: 5, keyword: "인문학", hits: 10 },
+    { keyword: "건강", hits: 50 },
+    { keyword: "취업", hits: 30 },
+    { keyword: "생애설계", hits: 30 },
+    { keyword: "교육", hits: 20 },
+    { keyword: "인문학", hits: 10 },
   ],
   user: true,
 };

--- a/src/api/rank/readEducationInterestRank.ts
+++ b/src/api/rank/readEducationInterestRank.ts
@@ -1,12 +1,13 @@
-import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
+import axios from "@api/axiosInstance";
+import { IRankEducationUserData } from "@type/rank";
+import { TInterest } from "@type/userForm";
+import { useAppSelector } from "@toolkit/hook";
 
-export const readEducationInterestRank = async (
-  interest: string | null = null
-) => {
-  const params: { interest?: string } = {};
-  if (interest) params.interest = interest;
+export const readEducationInterestRank = async (interest: TInterest | "") => {
+  const params: { interest?: TInterest } = {};
+  if (interest !== "") params.interest = interest;
 
-  // 전체 혹은 관심사별 교육 정보 최다 조회 게시글 Top5
   try {
     const response = await axios.get(`/educations/topFive/hits`, {
       params,
@@ -18,4 +19,14 @@ export const readEducationInterestRank = async (
     console.error("readEducationInterestRank 오류:", error);
     return false;
   }
+};
+
+// 전체 혹은 관심사별 교육 정보 최다 조회 게시글 Top5
+export const useReadEducationInterestRank = () => {
+  const interest = useAppSelector((state) => state.interest.selectedInterest);
+
+  return useQuery<IRankEducationUserData>({
+    queryKey: ["educations", "topFive", "hits", interest],
+    queryFn: () => readEducationInterestRank(interest),
+  });
 };

--- a/src/api/rank/readKeywordAgeRank.ts
+++ b/src/api/rank/readKeywordAgeRank.ts
@@ -1,15 +1,17 @@
+import axios from "@api/axiosInstance";
+import { useQuery } from "@tanstack/react-query";
+import { useAppSelector } from "@toolkit/hook";
+import { IRankKeywordsUserData } from "@type/rank";
 import { TAge } from "@type/userForm";
-import axios from "axios";
 
-export const readKeywordAgeRank = async (age: TAge) => {
-  const params: { ages?: string } = {};
+export const readKeywordAgeRank = async (age: TAge | "") => {
+  const params: { ages?: TAge } = {};
 
   //! age로 사용되던 값이 쿼리 파람에만 ages로 요청을 보냄
-  if (age) params.ages = age; // 연령대가 있을 경우 params에 추가
+  if (age !== "") params.ages = age; // 연령대가 있을 경우 params에 추가
 
-  // 전체 혹은 연령대별 교육 정보 최다 검색 키워드 Top5
   try {
-    const response = await axios.get("/educations/topFive/keyword", { params });
+    const response = await axios.get("/user/topFive/keyword", { params });
     if (response.status === 200) {
       return response.data;
     }
@@ -17,4 +19,14 @@ export const readKeywordAgeRank = async (age: TAge) => {
     console.error("readKeywordAgeRank 오류:", error);
     return false;
   }
+};
+
+// 전체 혹은 연령대별 교육 정보 최다 검색 키워드 Top5
+export const useReadKeywordAgeRank = () => {
+  const age = useAppSelector((state) => state.age.selectedAge);
+
+  return useQuery<IRankKeywordsUserData>({
+    queryKey: ["user", "topFive", "keyword", age],
+    queryFn: () => readKeywordAgeRank(age),
+  });
 };

--- a/src/api/rank/readKeywordAgeRank.ts
+++ b/src/api/rank/readKeywordAgeRank.ts
@@ -2,8 +2,10 @@ import { TAge } from "@type/userForm";
 import axios from "axios";
 
 export const readKeywordAgeRank = async (age: TAge) => {
-  const params: { age?: string } = {};
-  if (age) params.age = age;
+  const params: { ages?: string } = {};
+
+  //! age로 사용되던 값이 쿼리 파람에만 ages로 요청을 보냄
+  if (age) params.ages = age; // 연령대가 있을 경우 params에 추가
 
   // 전체 혹은 연령대별 교육 정보 최다 검색 키워드 Top5
   try {

--- a/src/api/rank/readPostRank.ts
+++ b/src/api/rank/readPostRank.ts
@@ -1,7 +1,8 @@
-import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
+import axios from "@api/axiosInstance";
+import { IRankPostUserData } from "@type/rank";
 
 export const readPostRank = async () => {
-  // 전체 자유게시판 최다 조회 게시글 Top5
   try {
     const response = await axios.get(`/posts/topFive/hits`);
     if (response.status === 200) {
@@ -11,4 +12,12 @@ export const readPostRank = async () => {
     console.error("readPostRank 오류:", error);
     return false;
   }
+};
+
+// 전체 자유게시판 최다 조회 게시글 Top5
+export const useReadPostRank = () => {
+  return useQuery<IRankPostUserData>({
+    queryKey: ["posts", "topFive", "hits"],
+    queryFn: () => readPostRank(),
+  });
 };

--- a/src/api/user/createUser.tsx
+++ b/src/api/user/createUser.tsx
@@ -4,8 +4,8 @@ import { IUserForm } from "@type/userForm";
 // jwt를 쿠키에 저장 요청
 export default async function creatUser(formData: IUserForm) {
   try {
-    const { gender, ages, location, interest } = formData;
-    const data = { gender, ages, location, interest };
+    const { gender, age, location, interest } = formData;
+    const data = { gender, age, location, interest };
     await axios.post("/user", data);
     return true;
   } catch (err) {

--- a/src/components/Rank/DropdownItems/AgeDropDown.tsx
+++ b/src/components/Rank/DropdownItems/AgeDropDown.tsx
@@ -1,11 +1,11 @@
 import { useDispatch } from "react-redux";
 import { useAppSelector } from "@toolkit/hook";
-import { ageActions } from "@features/rank/agesSlice";
-import { agesDataArr } from "@constants/userForm/userFormData";
+import { ageActions } from "@features/rank/ageSlice";
+import { ageDataArr } from "@constants/userForm/userFormData";
 
 export default function AgeDropDown() {
   const dispatch = useDispatch();
-  const { isOpen, selectedAgesStr } = useAppSelector((state) => state.ages);
+  const { isOpen, selectedageStr } = useAppSelector((state) => state.age);
 
   return (
     <div className="col-center relative">
@@ -14,19 +14,19 @@ export default function AgeDropDown() {
         className="w-1/2 rounded-t-md bg-main_color/90 text-font_white shadow-md"
         onClick={() => dispatch(ageActions.toggleOpen())}
       >
-        {selectedAgesStr === "" ? "연령대별로 더보기" : selectedAgesStr}
+        {selectedageStr === "" ? "연령대별로 더보기" : selectedageStr}
       </button>
 
       {/* Dropdown */}
       {isOpen && (
         <ul className="col-center z-1 absolute top-6 w-1/2  rounded-b-md bg-white shadow-md">
-          {agesDataArr.map((agesData, indx) => (
+          {ageDataArr.map((ageData, indx) => (
             <li
-              key={indx + agesData.ages}
+              key={indx + ageData.age}
               className="col-center w-40 border-b"
-              onClick={() => dispatch(ageActions.selectAge({ ...agesData }))}
+              onClick={() => dispatch(ageActions.selectAge({ ...ageData }))}
             >
-              {agesData.agesStr}
+              {ageData.ageStr}
             </li>
           ))}
 

--- a/src/components/Rank/EducationRank/index.tsx
+++ b/src/components/Rank/EducationRank/index.tsx
@@ -6,33 +6,38 @@ export default function EducationRank() {
   const { data, isLoading, isError } = useReadEducationInterestRank();
 
   return (
-    <>
+    <section>
+      {/* //! 유저 유무에 따른 연령대별 토글 버튼 */}
       {isLoading ? (
         <div></div>
       ) : isError ? (
-        <div>에러가 발생했습니다.</div>
+        <div>유저 정보를 받지 못했습니다.</div>
       ) : (
-        data && (
-          <section>
-            {/* //! 유저 유무에 따른 관심사 토글 버튼 */}
-            {data.user && <InterestDropDown />}
+        data.user && <InterestDropDown />
+      )}
 
-            {/* //! 교육정보 최다조회 게시글 Top5 */}
-            <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-              <h3 className="mb-4 text-center text-lg font-medium">
-                지난주에 가장 인기 있던 교육 정보예요.
-              </h3>
+      {/* //! 교육정보 최다조회 게시글 Top5 */}
+      <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+        <h3 className="mb-4 text-center text-lg font-medium">
+          지난주에 가장 인기 있던 교육 정보예요.
+        </h3>
 
-              {/* 교육정보 최다조회 Top 5 */}
+        {isLoading ? (
+          <div></div>
+        ) : isError ? (
+          <div>에러가 발생했습니다.</div>
+        ) : (
+          data && (
+            <>
               {data.data.length > 0 ? (
                 <EducationRankList data={data.data} />
               ) : (
-                <div>데이터가 없습니다.</div>
+                <div>지난주 기록이 없습니다.</div>
               )}
-            </div>
-          </section>
-        )
-      )}
-    </>
+            </>
+          )
+        )}
+      </div>
+    </section>
   );
 }

--- a/src/components/Rank/EducationRank/index.tsx
+++ b/src/components/Rank/EducationRank/index.tsx
@@ -1,26 +1,34 @@
-import { rankEducationUserData } from "public/data/rankingData";
 import EducationRankList from "./EducationRankList";
 import InterestDropDown from "../DropdownItems/InterestDropDown";
+import { useReadEducationInterestRank } from "@api/rank/readEducationInterestRank";
 
 export default function EducationRank() {
-  // 더미 데이터
-  const data = rankEducationUserData.data;
-  const user = rankEducationUserData.user;
+  const { data, isLoading, isError } = useReadEducationInterestRank();
 
   return (
-    <section>
-      {/* //! 유저 유무에 따른 관심사 토글 버튼 */}
-      {user && <InterestDropDown />}
+    <>
+      {isLoading ? (
+        <div></div>
+      ) : isError ? (
+        <div>에러가 발생했습니다.</div>
+      ) : (
+        data.data.length > 0 && (
+          <section>
+            {/* //! 유저 유무에 따른 관심사 토글 버튼 */}
+            {data.user && <InterestDropDown />}
 
-      {/* 교육정보 최다조회 게시글 Top5 */}
-      <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-        <h3 className="mb-4 text-center text-lg font-medium">
-          지난주에 가장 인기 있던 교육 정보예요.
-        </h3>
+            {/* 교육정보 최다조회 게시글 Top5 */}
+            <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+              <h3 className="mb-4 text-center text-lg font-medium">
+                지난주에 가장 인기 있던 교육 정보예요.
+              </h3>
 
-        {/* 교육 정보 리스트 */}
-        <EducationRankList data={data} />
-      </div>
-    </section>
+              {/* 교육 정보 리스트 */}
+              <EducationRankList data={data.data} />
+            </div>
+          </section>
+        )
+      )}
+    </>
   );
 }

--- a/src/components/Rank/EducationRank/index.tsx
+++ b/src/components/Rank/EducationRank/index.tsx
@@ -8,7 +8,7 @@ export default function EducationRank() {
   const user = rankEducationUserData.user;
 
   return (
-    <>
+    <section>
       {/* //! 유저 유무에 따른 관심사 토글 버튼 */}
       {user && <InterestDropDown />}
 
@@ -21,6 +21,6 @@ export default function EducationRank() {
         {/* 교육 정보 리스트 */}
         <EducationRankList data={data} />
       </div>
-    </>
+    </section>
   );
 }

--- a/src/components/Rank/EducationRank/index.tsx
+++ b/src/components/Rank/EducationRank/index.tsx
@@ -12,19 +12,23 @@ export default function EducationRank() {
       ) : isError ? (
         <div>에러가 발생했습니다.</div>
       ) : (
-        data.data.length > 0 && (
+        data && (
           <section>
             {/* //! 유저 유무에 따른 관심사 토글 버튼 */}
             {data.user && <InterestDropDown />}
 
-            {/* 교육정보 최다조회 게시글 Top5 */}
+            {/* //! 교육정보 최다조회 게시글 Top5 */}
             <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
               <h3 className="mb-4 text-center text-lg font-medium">
                 지난주에 가장 인기 있던 교육 정보예요.
               </h3>
 
-              {/* 교육 정보 리스트 */}
-              <EducationRankList data={data.data} />
+              {/* 교육정보 최다조회 Top 5 */}
+              {data.data.length > 0 ? (
+                <EducationRankList data={data.data} />
+              ) : (
+                <div>데이터가 없습니다.</div>
+              )}
             </div>
           </section>
         )

--- a/src/components/Rank/KewordRank/PieChart/index.tsx
+++ b/src/components/Rank/KewordRank/PieChart/index.tsx
@@ -2,9 +2,9 @@ import { Pie } from "react-chartjs-2";
 import { Chart, ChartOptions, ArcElement, Tooltip, Legend } from "chart.js";
 import ChartDataLabels from "chartjs-plugin-datalabels";
 import { round, sum } from "lodash";
-import { IRankKeywordsData } from "@type/rank";
+import { IRankKeywordData } from "@type/rank";
 
-export default function PieChart({ data }: { data: IRankKeywordsData[] }) {
+export default function PieChart({ data }: { data: IRankKeywordData[] }) {
   Chart.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 
   const labels = data.map((item) => item.keyword);
@@ -62,14 +62,6 @@ export default function PieChart({ data }: { data: IRankKeywordsData[] }) {
   return (
     <div className=" bg-ma col-center w-full gap-4">
       <Pie data={chartData} options={options} />
-      {/* <div>
-        {labels.map((label, idx) => (
-          <p key={idx}>
-            {`"${label}" : ${values[idx]} 번 검색되었어요.`}
-            <br />
-          </p>
-        ))}
-      </div> */}
     </div>
   );
 }

--- a/src/components/Rank/KewordRank/index.tsx
+++ b/src/components/Rank/KewordRank/index.tsx
@@ -1,25 +1,34 @@
 import PieChart from "./PieChart";
 import AgeDropDown from "../DropdownItems/AgeDropDown";
-import { rankEducationUserKeywords } from "public/data/rankingData";
+import { useReadKeywordAgeRank } from "@api/rank/readKeywordAgeRank";
 
 export default function KeywordRank() {
-  const data = rankEducationUserKeywords;
-  const user = data.user;
+  const { data, isLoading, isError } = useReadKeywordAgeRank();
 
   return (
-    <section>
-      {/* 유저 정보가 있는 경우 */}
-      {user && <AgeDropDown />}
+    <>
+      {isLoading ? (
+        <div></div>
+      ) : isError ? (
+        <div>에러가 발생했습니다.</div>
+      ) : (
+        data.data.length > 0 && (
+          <section>
+            {/* //! 유저 유무에 따른 연령대별 토글 버튼 */}
+            {data.user && <AgeDropDown />}
 
-      {/* 연령대별 교육정보 최다 검색 키워드 Top5 */}
-      <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-        <h3 className="mb-4 text-center text-lg font-medium">
-          지난주에 가장 많이 검색된 단어예요.
-        </h3>
+            {/* 연령대별 교육정보 최다 검색 키워드 Top5 */}
+            <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+              <h3 className="mb-4 text-center text-lg font-medium">
+                지난주에 가장 많이 검색된 단어예요.
+              </h3>
 
-        {/* 파이 차트 시각화 */}
-        <PieChart data={data.data} />
-      </div>
-    </section>
+              {/* 파이 차트 시각화 */}
+              <PieChart data={data.data} />
+            </div>
+          </section>
+        )
+      )}
+    </>
   );
 }

--- a/src/components/Rank/KewordRank/index.tsx
+++ b/src/components/Rank/KewordRank/index.tsx
@@ -12,19 +12,23 @@ export default function KeywordRank() {
       ) : isError ? (
         <div>에러가 발생했습니다.</div>
       ) : (
-        data.data.length > 0 && (
+        data && (
           <section>
             {/* //! 유저 유무에 따른 연령대별 토글 버튼 */}
             {data.user && <AgeDropDown />}
 
-            {/* 연령대별 교육정보 최다 검색 키워드 Top5 */}
+            {/* //! 교육정보 최다검색 키워드 Top5 */}
             <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
               <h3 className="mb-4 text-center text-lg font-medium">
                 지난주에 가장 많이 검색된 단어예요.
               </h3>
 
               {/* 파이 차트 시각화 */}
-              <PieChart data={data.data} />
+              {data.data.length > 0 ? (
+                <PieChart data={data.data} />
+              ) : (
+                <div>데이터가 없습니다.</div>
+              )}
             </div>
           </section>
         )

--- a/src/components/Rank/KewordRank/index.tsx
+++ b/src/components/Rank/KewordRank/index.tsx
@@ -7,7 +7,7 @@ export default function KeywordRank() {
   const user = data.user;
 
   return (
-    <>
+    <section>
       {/* 유저 정보가 있는 경우 */}
       {user && <AgeDropDown />}
 
@@ -20,6 +20,6 @@ export default function KeywordRank() {
         {/* 파이 차트 시각화 */}
         <PieChart data={data.data} />
       </div>
-    </>
+    </section>
   );
 }

--- a/src/components/Rank/KewordRank/index.tsx
+++ b/src/components/Rank/KewordRank/index.tsx
@@ -6,33 +6,38 @@ export default function KeywordRank() {
   const { data, isLoading, isError } = useReadKeywordAgeRank();
 
   return (
-    <>
+    <section>
+      {/* //! 유저 유무에 따른 연령대별 토글 버튼 */}
       {isLoading ? (
         <div></div>
       ) : isError ? (
-        <div>에러가 발생했습니다.</div>
+        <div>유저 정보를 받지 못했습니다.</div>
       ) : (
-        data && (
-          <section>
-            {/* //! 유저 유무에 따른 연령대별 토글 버튼 */}
-            {data.user && <AgeDropDown />}
+        data.user && <AgeDropDown />
+      )}
 
-            {/* //! 교육정보 최다검색 키워드 Top5 */}
-            <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-              <h3 className="mb-4 text-center text-lg font-medium">
-                지난주에 가장 많이 검색된 단어예요.
-              </h3>
+      {/* //! 교육정보 최다검색 키워드 Top5 */}
+      <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+        <h3 className="mb-4 text-center text-lg font-medium">
+          지난주에 가장 많이 검색된 단어예요.
+        </h3>
 
-              {/* 파이 차트 시각화 */}
+        {isLoading ? (
+          <div></div>
+        ) : isError ? (
+          <div>에러가 발생했습니다.</div>
+        ) : (
+          data && (
+            <>
               {data.data.length > 0 ? (
                 <PieChart data={data.data} />
               ) : (
-                <div>데이터가 없습니다.</div>
+                <div>지난주 기록이 없습니다.</div>
               )}
-            </div>
-          </section>
-        )
-      )}
-    </>
+            </>
+          )
+        )}
+      </div>
+    </section>
   );
 }

--- a/src/components/Rank/PostRank/index.tsx
+++ b/src/components/Rank/PostRank/index.tsx
@@ -5,27 +5,27 @@ export default function PostRank() {
   const { data, isLoading, isError } = useReadPostRank();
 
   return (
-    <>
+    <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+      <h3 className="mb-4 text-center text-lg font-medium">
+        지난주에 가장 인기 있던 게시글이에요.
+      </h3>
+
+      {/* //! 자유게시판 최다조회 게시글 Top 5 */}
       {isLoading ? (
         <div></div>
       ) : isError ? (
         <div>에러가 발생했습니다.</div>
       ) : (
         data && (
-          <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-            <h3 className="mb-4 text-center text-lg font-medium">
-              지난주에 가장 인기 있던 게시글이에요.
-            </h3>
-
-            {/* //! 자유게시판 최다조회 게시글 Top 5 */}
+          <>
             {data.data.length > 0 ? (
               <PostRankList data={data.data} />
             ) : (
-              <div>데이터가 없습니다.</div>
+              <div>지난주 기록이 없습니다.</div>
             )}
-          </section>
+          </>
         )
       )}
-    </>
+    </section>
   );
 }

--- a/src/components/Rank/PostRank/index.tsx
+++ b/src/components/Rank/PostRank/index.tsx
@@ -11,14 +11,18 @@ export default function PostRank() {
       ) : isError ? (
         <div>에러가 발생했습니다.</div>
       ) : (
-        data.data.length > 0 && (
+        data && (
           <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
             <h3 className="mb-4 text-center text-lg font-medium">
               지난주에 가장 인기 있던 게시글이에요.
             </h3>
 
-            {/* 자유게시판 최다조회 게시글 Top5 리스트 */}
-            <PostRankList data={data.data} />
+            {/* //! 자유게시판 최다조회 게시글 Top 5 */}
+            {data.data.length > 0 ? (
+              <PostRankList data={data.data} />
+            ) : (
+              <div>데이터가 없습니다.</div>
+            )}
           </section>
         )
       )}

--- a/src/components/Rank/PostRank/index.tsx
+++ b/src/components/Rank/PostRank/index.tsx
@@ -1,18 +1,27 @@
-import { rankPostData } from "public/data/rankingData";
+import { useReadPostRank } from "@api/rank/readPostRank";
 import PostRankList from "./PostRankList";
 
 export default function PostRank() {
-  // 더미 데이터
-  const data = rankPostData;
+  const { data, isLoading, isError } = useReadPostRank();
 
   return (
-    <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
-      <h3 className="mb-4 text-center text-lg font-medium">
-        지난주에 가장 인기 있던 게시글이에요.
-      </h3>
+    <>
+      {isLoading ? (
+        <div></div>
+      ) : isError ? (
+        <div>에러가 발생했습니다.</div>
+      ) : (
+        data.data.length > 0 && (
+          <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+            <h3 className="mb-4 text-center text-lg font-medium">
+              지난주에 가장 인기 있던 게시글이에요.
+            </h3>
 
-      {/* 자유게시판 최다조회 게시글 Top5 리스트 */}
-      <PostRankList data={data} />
-    </section>
+            {/* 자유게시판 최다조회 게시글 Top5 리스트 */}
+            <PostRankList data={data.data} />
+          </section>
+        )
+      )}
+    </>
   );
 }

--- a/src/components/Rank/PostRank/index.tsx
+++ b/src/components/Rank/PostRank/index.tsx
@@ -6,13 +6,13 @@ export default function PostRank() {
   const data = rankPostData;
 
   return (
-    <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
+    <section className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
       <h3 className="mb-4 text-center text-lg font-medium">
         지난주에 가장 인기 있던 게시글이에요.
       </h3>
 
       {/* 자유게시판 최다조회 게시글 Top5 리스트 */}
       <PostRankList data={data} />
-    </div>
+    </section>
   );
 }

--- a/src/components/Rank/SearchKeywordRank/SearchKeywordRankItem/index.tsx
+++ b/src/components/Rank/SearchKeywordRank/SearchKeywordRankItem/index.tsx
@@ -1,18 +1,18 @@
-import { IRankKeywordsData } from "@type/rank";
+import { IRankKeywordData } from "@type/rank";
 
 export default function SearchKeywordRankItem({
-  keywords,
+  data,
 }: {
-  keywords: IRankKeywordsData;
+  data: IRankKeywordData;
 }) {
   return (
     <li className="border-b">
       <div className="my-1 flex justify-between">
         {/* 키워드 */}
-        <span className="text-lg">{keywords.keyword}</span>
+        <span className="text-lg">{data.keyword}</span>
 
         {/* 조회수 */}
-        <span className=" text-md text-gray-500">조회 {keywords.hits}</span>
+        <span className=" text-md text-gray-500">조회 {data.hits}</span>
       </div>
     </li>
   );

--- a/src/components/Rank/SearchKeywordRank/SearchKeywordRankList/index.tsx
+++ b/src/components/Rank/SearchKeywordRank/SearchKeywordRankList/index.tsx
@@ -1,18 +1,18 @@
-import { IRankKeywordsData } from "@type/rank";
+import { IRankKeywordData } from "@type/rank";
 import SearchKeywordRankItem from "../SearchKeywordRankItem";
 
 export default function SearchKeywordRankList({
-  data,
+  dataArr,
 }: {
-  data: IRankKeywordsData[];
+  dataArr: IRankKeywordData[];
 }) {
   return (
     <div className="col-center w-full gap-4">
       <ul className="grid w-full grid-cols-1">
-        {data.map((keyword) => (
+        {dataArr.map((data, index) => (
           <SearchKeywordRankItem
-            key={keyword.id}
-            keywords={keyword as IRankKeywordsData}
+            key={`${index}.${data.keyword}`}
+            data={data as IRankKeywordData}
           />
         ))}
       </ul>

--- a/src/components/Rank/SearchKeywordRank/index.tsx
+++ b/src/components/Rank/SearchKeywordRank/index.tsx
@@ -2,7 +2,7 @@ import { rankEducationUserKeywords } from "public/data/rankingData";
 import SearchKeywordRankList from "./SearchKeywordRankList";
 
 export default function SearchKeywordRank() {
-  const data = rankEducationUserKeywords;
+  const data = rankEducationUserKeywords.data;
 
   return (
     <div className="mb-8 rounded-2xl bg-main_color/5 p-4 shadow-md">
@@ -12,7 +12,7 @@ export default function SearchKeywordRank() {
       </h3>
 
       {/* 리스트 */}
-      <SearchKeywordRankList data={data.data} />
+      <SearchKeywordRankList dataArr={data} />
     </div>
   );
 }

--- a/src/components/UserForm/index.tsx
+++ b/src/components/UserForm/index.tsx
@@ -2,7 +2,7 @@ import { IUserForm } from "@type/userForm";
 import { useForm, SubmitHandler, Controller } from "react-hook-form";
 import {
   genders,
-  agesDataArr,
+  ageDataArr,
   locations,
   interests,
 } from "@constants/userForm/userFormData";
@@ -28,7 +28,7 @@ export default function UserForm() {
 
   const onValid: SubmitHandler<IUserForm> = async (data) => {
     if (
-      !data.ages ||
+      !data.age ||
       !data.gender ||
       data.location === "" ||
       data.interest === "" ||
@@ -37,7 +37,7 @@ export default function UserForm() {
       const errMsg: { [key: string]: string } = {};
 
       if (!data.gender) errMsg.gender = "성별을 골라주세요.";
-      if (!data.ages) errMsg.age = "연령대를 골라주세요.";
+      if (!data.age) errMsg.age = "연령대를 골라주세요.";
       if (data.location === "") errMsg.location = "거주 지역을 골라주세요.";
       if (data.interest === "") errMsg.interest = "관심사를 골라주세요.";
       if (!data.confirm) errMsg.confirm = "동의를 해주세요";
@@ -45,7 +45,7 @@ export default function UserForm() {
       const setErrors = (errors: Record<string, string>) => {
         Object.entries(errors).forEach(([key, value]) => {
           setError(
-            key as "gender" | "ages" | "location" | "interest" | "confirm",
+            key as "gender" | "age" | "location" | "interest" | "confirm",
             {
               message: value,
               type: "required",
@@ -84,7 +84,7 @@ export default function UserForm() {
       ></motion.div>
 
       {/* 유저 폼 영역 */}
-      {genders && agesDataArr && locations && interests && (
+      {genders && ageDataArr && locations && interests && (
         <div className="col-center relative left-0 right-0">
           <motion.form
             initial={{ opacity: 0 }}
@@ -142,11 +142,11 @@ export default function UserForm() {
               <div className="row-start gap-4">
                 <span className="font-bold">연령대</span>
                 <span className="text-sm text-main_color">
-                  {errors.ages?.message}
+                  {errors.age?.message}
                 </span>
               </div>
               <Controller
-                name="ages"
+                name="age"
                 control={control}
                 render={({ field }) => {
                   return (
@@ -154,30 +154,30 @@ export default function UserForm() {
                       {...field}
                       className="grid w-full grid-cols-2 justify-stretch gap-3 sm:grid-cols-3"
                     >
-                      {agesDataArr.map((agesData) => {
+                      {ageDataArr.map((data) => {
                         return (
                           <label
-                            htmlFor={agesData.ages}
-                            key={agesData.ages}
+                            htmlFor={data.age}
+                            key={data.age}
                             className={`undraggable rounded-2xl border border-main_color px-3 py-0.5 transition-all ${classNames(
                               {
                                 "bg-main_color font-bold text-font_white shadow-md":
-                                  field.value === agesData.ages,
+                                  field.value === data.age,
                               }
                             )}`}
                           >
                             <input
                               type="radio"
-                              id={agesData.ages}
-                              name={agesData.ages}
-                              value={agesData.ages}
-                              checked={field.value == agesData.ages}
+                              id={data.age}
+                              name={data.age}
+                              value={data.age}
+                              checked={field.value == data.age}
                               onChange={(e) => {
                                 field.onChange(e.target.value);
                               }}
                               className="hidden"
                             />
-                            {agesData.agesStr}
+                            {data.ageStr}
                           </label>
                         );
                       })}

--- a/src/constants/userForm/userFormData.ts
+++ b/src/constants/userForm/userFormData.ts
@@ -1,14 +1,14 @@
-import { IAgesData, TInterest } from "@type/userForm";
+import { IAgeData, TInterest } from "@type/userForm";
 
 export const genders = ["남성", "여성"];
 
-export const agesDataArr: IAgesData[] = [
-  { agesStr: "49세 이하", ages: "0-49" },
-  { agesStr: "50 - 54세", ages: "50-54" },
-  { agesStr: "55 - 59세", ages: "55-59" },
-  { agesStr: "60 - 64세", ages: "60-64" },
-  { agesStr: "65 - 69세", ages: "65-69" },
-  { agesStr: "70세 이상", ages: "70-100" },
+export const ageDataArr: IAgeData[] = [
+  { ageStr: "49세 이하", age: "0-49" },
+  { ageStr: "50 - 54세", age: "50-54" },
+  { ageStr: "55 - 59세", age: "55-59" },
+  { ageStr: "60 - 64세", age: "60-64" },
+  { ageStr: "65 - 69세", age: "65-69" },
+  { ageStr: "70세 이상", age: "70-100" },
 ];
 
 export const locations = [

--- a/src/features/rank/ageSlice.ts
+++ b/src/features/rank/ageSlice.ts
@@ -1,15 +1,15 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
-import { IAgesState } from "@type/rank";
-import { IAgesData } from "@type/userForm";
+import { IAgeState } from "@type/rank";
+import { IAgeData } from "@type/userForm";
 
-const initialState: IAgesState = {
+const initialState: IAgeState = {
   isOpen: false,
-  selectedAgesStr: "",
-  selectedAges: "",
+  selectedageStr: "",
+  selectedAge: "",
 };
 
 export const agesSlice = createSlice({
-  name: "ages",
+  name: "age",
   initialState,
   reducers: {
     // 더보기 버튼 열고 닫을 때
@@ -18,16 +18,16 @@ export const agesSlice = createSlice({
     },
 
     // 연령별 버튼 클릭했을 때 : ages
-    selectAge: (state, actions: PayloadAction<IAgesData>) => {
-      state.selectedAgesStr = actions.payload.agesStr;
-      state.selectedAges = actions.payload.ages;
+    selectAge: (state, actions: PayloadAction<IAgeData>) => {
+      state.selectedageStr = actions.payload.ageStr;
+      state.selectedAge = actions.payload.age;
       state.isOpen = false;
     },
 
     // "전체" 버튼 클릭했을 때
     selectTotal: (state) => {
-      state.selectedAgesStr = "";
-      state.selectedAges = "";
+      state.selectedageStr = "";
+      state.selectedAge = "";
       state.isOpen = false;
     },
   },

--- a/src/toolkit/store.ts
+++ b/src/toolkit/store.ts
@@ -8,7 +8,7 @@ import userFormReducer from "@features/userForm/userFormSlice";
 import commentReducer from "@features/comment/commentSlice";
 import chatReducer from "@features/chat/chatSlice";
 import interestReducer from "@features/rank/interestSlice";
-import agesReducer from "@features/rank/agesSlice";
+import ageReducer from "@features/rank/ageSlice";
 
 export const store = configureStore({
   reducer: {
@@ -20,7 +20,7 @@ export const store = configureStore({
     comment: commentReducer,
     chat: chatReducer,
     interest: interestReducer,
-    ages: agesReducer,
+    age: ageReducer,
   },
   // middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });

--- a/src/type/rank.ts
+++ b/src/type/rank.ts
@@ -37,15 +37,14 @@ export interface IRankEducationUserData {
 }
 
 // 교육 정보 최다 검색 랭킹 데이터 : 전체
-export interface IRankKeywordsData {
-  id: number;
+export interface IRankKeywordData {
   keyword: string;
   hits: number;
 }
 
 // 교육 정보 최다 검색 랭킹 데이터 : 유저 정보 포함
 export interface IRankKeywordsUserData {
-  data: IRankKeywordsData[];
+  data: IRankKeywordData[];
   user: boolean;
 }
 

--- a/src/type/rank.ts
+++ b/src/type/rank.ts
@@ -1,4 +1,4 @@
-import { TAges, TAgesStr, TInterest } from "./userForm";
+import { TAge, TAgeStr, TInterest } from "./userForm";
 
 // 자유게시판 최다 조회 랭킹 데이터 : 전체
 export interface IRankPostData {
@@ -48,11 +48,11 @@ export interface IRankKeywordsUserData {
   user: boolean;
 }
 
-// AgesState
-export interface IAgesState {
+// AgeState
+export interface IAgeState {
   isOpen: boolean;
-  selectedAgesStr: TAgesStr | "";
-  selectedAges: TAges | "";
+  selectedageStr: TAgeStr | "";
+  selectedAge: TAge | "";
 }
 
 // InterestState

--- a/src/type/userForm.ts
+++ b/src/type/userForm.ts
@@ -1,6 +1,6 @@
 export interface IUserForm {
   gender: TGender;
-  ages: TAges;
+  age: TAge;
   location: TLocation | "";
   interest: TInterest | "";
   confirm: Tconfirm;
@@ -10,20 +10,20 @@ export interface IUserFormState {
   showModal: boolean;
 }
 
-export interface IAgesData {
-  agesStr: TAgesStr;
-  ages: TAges;
+export interface IAgeData {
+  ageStr: TAgeStr;
+  age: TAge;
 }
 
 export type TGender = string;
-export type TAgesStr =
+export type TAgeStr =
   | "49세 이하"
   | "50 - 54세"
   | "55 - 59세"
   | "60 - 64세"
   | "65 - 69세"
   | "70세 이상";
-export type TAges = "0-49" | "50-54" | "55-59" | "60-64" | "65-69" | "70-100";
+export type TAge = "0-49" | "50-54" | "55-59" | "60-64" | "65-69" | "70-100";
 export type TLocation = string;
 export type TInterest = "취업" | "교육" | "취미" | "모임";
 export type Tconfirm = boolean;


### PR DESCRIPTION
## 🔥 Related Issue

close: #110 

## 📝 Description

- useQuery와 ageSlice, interestSlice를 통해서 커스텀 함수를 제작했습니다. 
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/b75039b4-e1a3-49c4-817b-6c258e1aa95f)

- 각 시각화 해주는 컴포넌트에 useQuery 커스텀 함수를 더미데이터 대신에 넣어주었습니다.
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/d067a840-dd77-44a4-b589-70263d4915e7)

- 모든 연령대 관련 데이터의 명칭을 age, ageStr, ageSlice, ageData 등으로 수정했습니다. (ages -> age)
- 하지만 쿼리파람을 주는 곳에서는 ages로 age 데이터를 보냅니다.
![image](https://github.com/kimyoo04/seoul-competition-frontend/assets/58503130/c74b3e5e-330b-4917-a8b5-3271a63c031e)